### PR TITLE
refactor: avoid ReDim Preserve for export array

### DIFF
--- a/Pricing_config.bas
+++ b/Pricing_config.bas
@@ -730,8 +730,15 @@ RowNext:
 
     If DEBUG_LOG Then Debug.Print "BuildFilteredExport: total exported=" & outIdx
     If outIdx = 0 Then GoTo Finish
-    ReDim Preserve outArr(1 To outIdx, 1 To width)
-    wsOut.Range("A2").Resize(outIdx, width).Value = outArr
+    Dim finalArr() As Variant
+    ReDim finalArr(1 To outIdx, 1 To width)
+    Dim c As Long
+    For r = 1 To outIdx
+        For c = 1 To width
+            finalArr(r, c) = outArr(r, c)
+        Next c
+    Next r
+    wsOut.Range("A2").Resize(outIdx, width).Value = finalArr
 
     Dim ni As Variant
     For Each ni In notes


### PR DESCRIPTION
## Summary
- avoid `ReDim Preserve` on `outArr` in `BuildFilteredExport`
- copy populated data into a final array before writing to the worksheet

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68c1a8bbd08c8330aa553ed20123582e